### PR TITLE
Add Netlify landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Paperless Pioneers</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; line-height: 1.6; }
+    code { background-color: #f4f4f4; padding: 2px 4px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Paperless Pioneers</h1>
+  <p>Dieses Projekt stellt ein einfaches Kommandozeilen-Werkzeug bereit, mit dem
+     Text aus PDF-Dateien extrahiert werden kann.</p>
+  <h2>Installation</h2>
+  <pre><code>pip install -r requirements.txt</code></pre>
+  <h2>Verwendung</h2>
+  <pre><code>python paperless.py pfad/zur/datei.pdf</code></pre>
+  <p>Der Text des PDFs wird danach im Terminal ausgegeben.</p>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  publish = "."


### PR DESCRIPTION
## Summary
- add a simple `index.html` so Netlify serves a page
- add `netlify.toml` configuring the publish directory

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile paperless.py`

------
https://chatgpt.com/codex/tasks/task_e_688333bbb43883209c5a3ce7461cdabb