### PR TITLE
Implement prototype of Invoice Inc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Node build output
+/dist
+node_modules
+
+# Python cache
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
+# Paperless Pioneers / Invoice Inc.
 
-# Paperless Pioneers
+This repository contains two experimental code bases:
 
-This project provides a simple command line tool to extract text from PDF files using [PyPDF2](https://pypi.org/project/PyPDF2/).
+1. **Paperless Pioneers** – a small Python command line tool for
+   extracting text from PDF files.
+2. **Invoice Inc.** – the beginning of an interactive learning game
+   about creating correct invoices. The game logic is implemented in
+   TypeScript and can be evolved modularly.
 
-## Setup
+## Paperless Pioneers
 
-Install dependencies using pip:
+Install the Python dependencies and run the script with a PDF file to
+print its text:
 
 ```bash
 pip install -r requirements.txt
-```
-
-## Usage
-
-Run the script with the path to a PDF file:
-
-```bash
 python paperless.py path/to/file.pdf
 ```
 
-The text of the PDF will be printed to standard output.
-=======
-# Invoice Inc
+## Invoice Inc.
 
-Ein Lernspiel zur Erstellung korrekter Rec
+The TypeScript part is organised in a small module structure under
+`src/`. Running `npx tsc` compiles the code to the `dist/` directory.
+A basic demo scenario can then be executed with Node:
+
+```bash
+npx tsc
+node dist/index.js
+```
+
+This will initialise a simple game sequence, validate a mock invoice and
+print the current score. The implementation is intentionally modular so
+that new events and rules can be added step by step under
+`src/modules` and `src/core`.

--- a/index.html
+++ b/index.html
@@ -18,5 +18,11 @@
   <h2>Verwendung</h2>
   <pre><code>python paperless.py pfad/zur/datei.pdf</code></pre>
   <p>Der Text des PDFs wird danach im Terminal ausgegeben.</p>
+
+  <h1>Invoice Inc.</h1>
+  <p>Der TypeScript-Code im Ordner <code>src/</code> bildet eine kleine Spiele-
+     Simulation rund um Rechnungen. Kompiliere ihn und starte die Demo mit:</p>
+  <pre><code>npx tsc
+node dist/index.js</code></pre>
 </body>
 </html>

--- a/src/core/invoiceGenerator.ts
+++ b/src/core/invoiceGenerator.ts
@@ -1,0 +1,18 @@
+import { Invoice } from './invoiceValidator';
+import { berechneUmsatzsteuer } from './taxEngine';
+
+export interface GeneratedInvoice extends Invoice {
+  brutto: number;
+}
+
+export function generateInvoice(
+  kunde: string,
+  leistung: string,
+  netto: number,
+  steuersatz: number,
+  lieferdatum: string
+): GeneratedInvoice {
+  const umsatzsteuer = berechneUmsatzsteuer(netto, steuersatz);
+  const brutto = +(netto + umsatzsteuer).toFixed(2);
+  return { kunde, leistung, betrag: netto, steuersatz, lieferdatum, brutto };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ import { initGame } from './modules/startGame/initGame';
 import { setupWorld } from './modules/startGame/setupWorld';
 import { introDialogue } from './modules/startGame/introDialogue';
 import { pruefeRechnung } from './core/invoiceValidator';
+import { generateInvoice } from './core/invoiceGenerator';
 import { ScoringSystem } from './core/scoringSystem';
+import { reverseChargeEvent } from './modules/events/reverseCharge';
 
 function main() {
   initGame();
@@ -10,9 +12,13 @@ function main() {
   introDialogue();
 
   const scoring = new ScoringSystem();
-  const fakeInvoice = { kunde: 'Test GmbH', leistung: 'Beratung', betrag: 1000, steuersatz: 19, lieferdatum: '2024-01-01' };
-  const fehler = pruefeRechnung(fakeInvoice);
-  if (fehler.length === 0) scoring.addPunkte(10);
+  const invoice = generateInvoice('Test GmbH', 'Beratung', 1000, 19, '2024-01-01');
+  const fehler = pruefeRechnung(invoice);
+  if (fehler.length === 0) {
+    scoring.addPunkte(10);
+  }
+  reverseChargeEvent();
+  console.log('Invoice:', invoice);
   console.log('Score:', scoring.score);
   console.log('Fehler:', fehler);
 }

--- a/src/modules/events/reverseCharge.ts
+++ b/src/modules/events/reverseCharge.ts
@@ -1,0 +1,3 @@
+export function reverseChargeEvent() {
+  console.log('Reverse-Charge-Fall: Kunde im EU-Ausland, Umsatzsteuer entfällt.');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -109,5 +109,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": ["src/ui/**/*"]
 }


### PR DESCRIPTION
## Summary
- add TypeScript demo for Invoice Inc with invoice generation and a reverse-charge event
- ignore build output via `.gitignore`
- document how to run the demo and PDF extractor
- update landing page with Invoice Inc instructions
- exclude React UI from TypeScript compilation

## Testing
- `npx tsc`
- `node dist/index.js`
- `pip install -r requirements.txt`
- `python paperless.py` *(fails: missing argument)*

------
https://chatgpt.com/codex/tasks/task_e_68833fad69088320a34151a15d685c98